### PR TITLE
Bugfix join on wrong ID

### DIFF
--- a/app/code/community/Lesti/Blog/Model/Resource/Author.php
+++ b/app/code/community/Lesti/Blog/Model/Resource/Author.php
@@ -64,7 +64,7 @@ class Lesti_Blog_Model_Resource_Author extends Mage_Core_Model_Resource_Db_Abstr
             )
             ->join(
                 array('bp' => $this->getTable('blog/post')),
-                'au.user_id = bp.author_id',
+                'ba.author_id = bp.author_id',
                 array()
             )
             ->join(


### PR DESCRIPTION
The post table needs to be joined on the author id, not admin id, otherwise it will return empty/wrong results in the case the author_id is != the admin_id (which often enough is not the case but does happen).